### PR TITLE
INSP-1537 - Forking and updating contentful_rails gem

### DIFF
--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -50,10 +50,6 @@ module ContentfulRails
       end
     end
 
-    initializer "add_contentful_mime_type" do
-      Mime::Type.register "application/json", :json, ["application/vnd.contentful.management.v1+json"]
-    end
-
     initializer "add_preview_support" do
       ActiveSupport.on_load(:action_controller) do
         include ContentfulRails::Preview

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -23,8 +23,10 @@ module ContentfulRails
     #Iterate through all models which inherit from ContentfulModel::Base
     #and add an entry mapping for them, so calls to the Contentful API return
     #the appropriate classes
+    #If ContentfulModel.configuration.entry_mapping is already configured from
+    #initializer, assuming that is the one to use and not running `add_entry_mapping`
     initializer "add_entry_mappings", after: :configure_contentful  do
-      if defined?(ContentfulModel)
+      if defined?(ContentfulModel) && ContentfulModel.configuration.entry_mapping.blank?
         Rails.application.eager_load!
         ContentfulModel::Base.descendents.each do |klass|
           klass.send(:add_entry_mapping)


### PR DESCRIPTION
So I went down a rabbit hole and eventually found that their `eager_load!` and overriding of the registered `:json` mime types were causing a bunch of issues with some of our angular features.  I also discovered that, because we're declaring the `entry_mapping` in the ContentfulRails configuration, there actually is no need at all to eager_load and make the call to the `add_entry_mapping` method.  

So I submitted a PR to their repo to remove it if that configuration exists.
We'll see what they think.  I'm also removing their mime type registration here because it shouldn't be needed and seems to prevent some of our angular features from correctly registering and parsing the json parameters.
